### PR TITLE
Correct typo in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.2.1"]
                                   [figwheel-sidecar "0.5.3"]]
-                   :source-paths ["src/clj src/cljs"]}}
+                   :source-paths ["src/clj" "src/cljs"]}}
 
   :repl-options {:init-ns atlas.core}
 


### PR DESCRIPTION
But is that line even needed? Shouldn't we just get rid of it?